### PR TITLE
Remove unncessary res.getViewData()

### DIFF
--- a/cartridges/sfra_demo/cartridge/controllers/Home.js
+++ b/cartridges/sfra_demo/cartridge/controllers/Home.js
@@ -10,7 +10,7 @@ server.append('Show', function (req, res, next) {
     var viewData = res.getViewData();
     viewData = {
         demo1: 'sfra_demo cartridge append happening',
-        demo2: 'this is the value overriden by the append'
+        demo2: 'this is the value overridden by the append'
     };
     res.setViewData(viewData);
     next();
@@ -19,8 +19,7 @@ server.append('Show', function (req, res, next) {
 
 /*** Demo for extending a script *******/
 server.append('Show', cache.applyCustomCache, function (req, res, next) {
-    var viewData = res.getViewData();
-    viewData = {
+    var viewData = {
         demo1: 'this homepage is using custom cache middleware',
         demo2: res.cachePeriod + '' + res.cachePeriodUnit
     };


### PR DESCRIPTION
If you're not using objects already inside viewData, there's no need to get it. We were overwriting it anyways with the following line, so I'm just getting rid of unnecessary work.

And fixing a typo.