### PR TITLE
Correcting template name

### DIFF
--- a/cartridges/sfra_demo/cartridge/controllers/AppendExample.js
+++ b/cartridges/sfra_demo/cartridge/controllers/AppendExample.js
@@ -4,7 +4,7 @@ var server = require('server');
 
 server.get('Start', function (req, res, next) {
 
-	res.render('viewdataexample', {param1:"Hello from AppendExample"});
+	res.render('pdictexample', {param1:"Hello from AppendExample"});
 	next();
 });
 


### PR DESCRIPTION
viewdataexample.isml doesn't exist in this project. A solution is to either point to pdictexample.isml, or duplicate pdictexample.isml as viewdataexample.isml (the latter being a good example of swapping templates using an appended route).